### PR TITLE
fix: don't include `const` declaration in `.d.ts`

### DIFF
--- a/plugins/render.ts
+++ b/plugins/render.ts
@@ -74,8 +74,7 @@ export const RenderPlugin = () => {
 
         // Generate types
         const types = [
-          `const defaultMessages = ${JSON.stringify(messages)}`,
-          'export type DefaultMessages = typeof defaultMessages',
+          `export type DefaultMessages = Record<${Object.keys(messages).map(a => `"${a}"`).join(' | ')}, string | boolean | number >`,
           'declare const template: (data: Partial<DefaultMessages>) => string',
           'export { template }'
         ].join('\n')


### PR DESCRIPTION
Previously a type check would reveal the following error (for each declaration):

```
node_modules/@nuxt/design/dist/templates/error-404.d.ts:1:1 - error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.

const defaultMessages = {"statusCode":"404","statusMessage":"Not Found","description":"Sorry, the page you are looking for could not be found.","backHome":"Go back home"}
  ~~~~~
```