### PR TITLE
fix: improve design of error pages

### DIFF
--- a/packages/templates/templates/error-500/index.html
+++ b/packages/templates/templates/error-500/index.html
@@ -30,6 +30,7 @@
           leading-normal
           dark:text-cloud-lighter
           md:text-3xl
+          max-w-sm
         ">
           {{ messages.description }}
         </div>

--- a/packages/templates/templates/error-500/index.html
+++ b/packages/templates/templates/error-500/index.html
@@ -17,22 +17,22 @@
       dark:text-sky-surface
     ">
   <div class="min-h-screen md:flex">
-    <div class="flex items-center justify-center w-full md:w-1/2">
-      <div class="max-w-sm m-8">
-        <div class="text-5xl font-bold dark:text-white md:text-15xl">
+    <div class="flex items-center justify-center w-full max-w-full">
+      <div class="max-w-full lg:max-w-10xl m-8 p-4">
+        <div class="md:max-w-sm text-5xl font-bold dark:text-white md:text-15xl">
           {{ messages.statusCode }}
         </div>
         <div class="w-16 h-1 my-3 bg-primary md:my-6"></div>
-        <p class="
-              mb-8
-              text-2xl
-              font-light
-              leading-normal
-              dark:text-cloud-lighter
-              md:text-3xl
-            ">
+        <div class="
+          mb-8
+          text-2xl
+          font-light
+          leading-normal
+          dark:text-cloud-lighter
+          md:text-3xl
+        ">
           {{ messages.description }}
-        </p>
+        </div>
       </div>
     </div>
     <div class="

--- a/packages/templates/templates/error-dev/index.html
+++ b/packages/templates/templates/error-dev/index.html
@@ -30,6 +30,7 @@
           leading-normal
           dark:text-cloud-lighter
           md:text-3xl
+          max-w-sm
         ">
           {{ messages.description }}
         </div>

--- a/packages/templates/templates/error-dev/index.html
+++ b/packages/templates/templates/error-dev/index.html
@@ -1,45 +1,53 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title>{{ messages.statusCode }} - {{ messages.statusMessage }} | {{ messages.appName }}</title>
-    <meta charset="utf-8" />
-    <meta
-      content="width=device-width,initial-scale=1.0,minimum-scale=1.0"
-      name="viewport"
-    />
-    <script type="module" src="/styles.ts"></script>
-  </head>
-  <body
-    class="
+
+<head>
+  <title>{{ messages.statusCode }} - {{ messages.statusMessage }} | {{ messages.appName }}</title>
+  <meta charset="utf-8" />
+  <meta content="width=device-width,initial-scale=1.0,minimum-scale=1.0" name="viewport" />
+  <script type="module" src="/styles.ts"></script>
+</head>
+
+<body class="
       font-sans
       antialiased
       bg-cloud-surface
       dark:bg-sky-darker
       text-sky-darkest
       dark:text-sky-surface
-    "
-  >
-    <div class="min-h-screen md:flex">
-      <div class="flex items-center justify-center w-full md:w-1/2">
-        <div class="max-w-sm m-8">
-          <div class="text-5xl font-bold dark:text-white md:text-15xl">
-            {{ messages.statusCode }}
-          </div>
-          <div class="w-16 h-1 my-3 bg-primary md:my-6"></div>
-          <p
-            class="
-              mb-8
-              text-2xl
-              font-light
-              leading-normal
-              dark:text-cloud-lighter
-              md:text-3xl
-            "
-          >
-            {{ messages.description }}
-          </p>
+    ">
+  <div class="min-h-screen md:flex">
+    <div class="flex items-center justify-center w-full max-w-full">
+      <div class="max-w-full lg:max-w-10xl m-8 p-4">
+        <div class="md:max-w-sm text-5xl font-bold dark:text-white md:text-15xl">
+          {{ messages.statusCode }}
+        </div>
+        <div class="w-16 h-1 my-3 bg-primary md:my-6"></div>
+        <div class="
+          mb-8
+          text-2xl
+          font-light
+          leading-normal
+          dark:text-cloud-lighter
+          md:text-3xl
+        ">
+          {{ messages.description }}
+        </div>
+        <div class="
+          mb-8
+          text-sm
+          leading-normal
+          dark:text-cloud-lighter
+          md:text-lg
+          white
+          overflow-scroll
+          max-w-full
+        ">
+          {{ messages.stack }}
         </div>
       </div>
     </div>
-  </body>
+  </div>
+</body>
+
 </html>

--- a/packages/templates/templates/error-dev/messages.json
+++ b/packages/templates/templates/error-dev/messages.json
@@ -2,6 +2,6 @@
   "statusCode": "500",
   "statusMessage": "Server error",
   "description": "An error occurred in the application and the page could not be served. If you are the application owner, check your server logs for details.",
-  "stack": "<pre><span class=\"stack\">at setup (file://./.nuxt/dist/server/server.mjs:9420:13)</span>\n<span class=\"stack\">at _sfc_main.setup (file://./.nuxt/dist/server/server.mjs:9555:23)</span>\n<span class=\"stack internal\">at callWithErrorHandling (/project/node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:157:22)</span>\n<span class=\"stack internal\">at setupStatefulComponent (/project/node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:6977:29)</span>\n<span class=\"stack internal\">at setupComponent (/project/node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:6933:11)</span>\n<span class=\"stack internal\">at renderComponentVNode (/project/node_modules/@vue/server-renderer/dist/server-renderer.cjs.js:198:17)</span>\n<span class=\"stack internal\">at Module.ssrRenderComponent (/project/node_modules/@vue/server-renderer/dist/server-renderer.cjs.js:629:12)</span>\n<span class=\"stack\">at default (file://./.nuxt/dist/server/server.mjs:9274:37)</span>\n<span class=\"stack internal\">at Module.<anonymous> (/project/node_modules/@vue/server-renderer/dist/server-renderer.cjs.js:958:13)</span>\n<span class=\"stack\">at Generator.next (<anonymous>)</span></pre>\n    "
+  "stack": ""
 
 }

--- a/packages/templates/templates/error-dev/messages.json
+++ b/packages/templates/templates/error-dev/messages.json
@@ -3,5 +3,4 @@
   "statusMessage": "Server error",
   "description": "An error occurred in the application and the page could not be served. If you are the application owner, check your server logs for details.",
   "stack": ""
-
 }

--- a/packages/templates/templates/error-dev/messages.json
+++ b/packages/templates/templates/error-dev/messages.json
@@ -1,5 +1,7 @@
 {
   "statusCode": "500",
   "statusMessage": "Server error",
-  "description": "An error occurred in the application and the page could not be served. If you are the application owner, check your server logs for details."
+  "description": "An error occurred in the application and the page could not be served. If you are the application owner, check your server logs for details.",
+  "stack": "<pre><span class=\"stack\">at setup (file://./.nuxt/dist/server/server.mjs:9420:13)</span>\n<span class=\"stack\">at _sfc_main.setup (file://./.nuxt/dist/server/server.mjs:9555:23)</span>\n<span class=\"stack internal\">at callWithErrorHandling (/project/node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:157:22)</span>\n<span class=\"stack internal\">at setupStatefulComponent (/project/node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:6977:29)</span>\n<span class=\"stack internal\">at setupComponent (/project/node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:6933:11)</span>\n<span class=\"stack internal\">at renderComponentVNode (/project/node_modules/@vue/server-renderer/dist/server-renderer.cjs.js:198:17)</span>\n<span class=\"stack internal\">at Module.ssrRenderComponent (/project/node_modules/@vue/server-renderer/dist/server-renderer.cjs.js:629:12)</span>\n<span class=\"stack\">at default (file://./.nuxt/dist/server/server.mjs:9274:37)</span>\n<span class=\"stack internal\">at Module.<anonymous> (/project/node_modules/@vue/server-renderer/dist/server-renderer.cjs.js:958:13)</span>\n<span class=\"stack\">at Generator.next (<anonymous>)</span></pre>\n    "
+
 }


### PR DESCRIPTION
Some slight tweaks to error pages. Mostly adds a separate stacktrace section for the dev error page, which can be scrolled horizontally for better viewing on mobile. And changes width so stacktrace isn't unduly constrained.

Happy for this to be improved.

## Mobile

<table>
<thead>
<tr>
<td>
New
</td>
<td>
Old
</td>
</tr>
<tbody>
<tr>
<td>

![Screen Shot 2022-03-10 at 12 23 37](https://user-images.githubusercontent.com/28706372/157661073-6b05a98c-cbb2-4f22-abd0-2b35607b8476.png)

</td>
<td>

![Screen Shot 2022-03-10 at 12 37 21](https://user-images.githubusercontent.com/28706372/157663309-59dc7dcb-7723-4628-b9b3-8022d5757d1b.png)

</td>
</tr>
<tr>
<td>

![Screen Shot 2022-03-10 at 12 29 07](https://user-images.githubusercontent.com/28706372/157661923-7bf86aad-0d95-4eee-ba0a-9d735050b63b.png)

</td>
<td>

![Screen Shot 2022-03-10 at 12 30 54](https://user-images.githubusercontent.com/28706372/157662248-5e5d6daf-16c3-4ef6-bb8c-1b87fd458b40.png)

</td>
</tr>
</tbody>
</table>


## Desktop

<table>
<thead>
<tr>
<td>
New
</td>
<td>
Old
</td>
</tr>
<tbody>
<tr>
<td>

![Screen Shot 2022-03-10 at 12 40 56](https://user-images.githubusercontent.com/28706372/157663803-e033535c-a9b3-4263-8110-21402d65421f.png)

</td>
<td>

![Screen Shot 2022-03-10 at 12 34 53](https://user-images.githubusercontent.com/28706372/157662942-251b1fc2-ba88-47f8-a226-5076b012c1ee.png)

</td>
</tr>
<tr>
<td>

![Screen Shot 2022-03-10 at 12 43 15](https://user-images.githubusercontent.com/28706372/157664192-c11853d2-71dc-42cd-81c1-42c8dcef8c39.png)

</td>
<td>

![Screen Shot 2022-03-10 at 12 35 14](https://user-images.githubusercontent.com/28706372/157662974-218de3c9-9dc8-4142-b229-752eee5b8417.png)

</td>
</tr>
</tbody>
</table>