### PR TITLE
style(404): simplify style and fix hover opacity transition

### DIFF
--- a/packages/templates/templates/error-404/index.html
+++ b/packages/templates/templates/error-404/index.html
@@ -14,39 +14,37 @@
       }
       .gradient-border {
         position: relative;
-        border-radius: 0.5rem;
+        --radius: 0.5rem;
+        --thickness: 2px;
+        border-radius: var(--radius);
         -webkit-backdrop-filter: blur(10px);
         backdrop-filter: blur(10px);
       }
       @media (prefers-color-scheme: light) {
         .gradient-border {
           background-color: rgba(255, 255, 255, 0.3);
+          border: var(--thickness) solid #e9eeef;
         }
         .gradient-border::before {
-          background: linear-gradient(90deg, #e2e2e2 0%, #e2e2e2 25%, #00DC82 50%, #36E4DA 75%, #0047E1 100%);
+          background: linear-gradient(90deg, transparent 50%, #00DC82 50%, #36E4DA 75%, #0047E1 100%);
         }
       }
       @media (prefers-color-scheme: dark) {
         .gradient-border {
           background-color: rgba(20, 20, 20, 0.3);
-        }
-        .gradient-border::before {
-          background: linear-gradient(90deg, #303030 0%, #303030 25%, #00DC82 50%, #36E4DA 75%, #0047E1 100%);
+          border: var(--thickness) solid #20292b;
         }
       }
       .gradient-border::before {
         content: "";
         position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        border-radius: 0.5rem;
-        padding: 2px;
-        width: 100%;
-        background-size: 400% auto;
+        inset: calc(var(--thickness) * -1);
+        border-radius:var(--radius);
+        padding: var(--thickness);
+        background-image: linear-gradient(90deg, transparent 50%, #00DC82 50%, #36E4DA 75%, #0047E1 100%);
+        background-size: 200% auto;
         opacity: 0.5;
-        transition: background-position 0.3s ease-in-out, opacity 0.2s ease-in-out;
+        transition: background-position 0.2s ease-in-out, opacity 0.2s ease-in-out;
         -webkit-mask:
           linear-gradient(#fff 0 0) content-box,
           linear-gradient(#fff 0 0);
@@ -57,7 +55,7 @@
                 mask-composite: exclude;
       }
       .gradient-border:hover::before {
-        background-position: -50% 0;
+        background-position: -100% 0;
         opacity: 1;
       }
     </style>
@@ -68,7 +66,7 @@
       <h1 class="text-8xl sm:text-10xl font-medium mb-8">{{ messages.statusCode }}</h1>
       <p class="text-xl px-8 sm:px-0 sm:text-4xl font-light mb-16 leading-tight">{{ messages.description }}</p>
       <div class="w-full flex items-center justify-center">
-        <a href="/" class="gradient-border text-md sm:text-xl py-2 px-4 sm:py-3 sm:px-6 cursor-pointer">
+        <a href="/" class="gradient-border text-md sm:text-xl py-1 px-3 sm:py-2 sm:px-5 cursor-pointer">
           {{ messages.backHome }}
         </a>
      </div>


### PR DESCRIPTION
Hi there! 👋

Well, you already fixed the border-radius problem I pointed out haha. 
But I managed to make some really small improvements (really, we're talking details here so maybe it's not even worth the change, you tell me!).

<img src="https://user-images.githubusercontent.com/10612835/161145292-31579b9b-b78d-4048-a560-a5d109c7da23.jpg" height="150px" width="auto">


Before:
![nuxt-ui-btn-hover](https://user-images.githubusercontent.com/10612835/161142258-bd518b9e-4d63-40ee-887d-4ffba195eaf5.gif)
After:
![nuxt-ui-btn-hover-after](https://user-images.githubusercontent.com/10612835/161142274-e80be149-f4ec-49df-a6af-a478aabf4cb0.gif)

1. With the current button style, there is a **little opacity fading on the white border**, before the gradient arrives. This is much more visible when we try to override the button background color (see gifs)

2. It could be seen as a feature, but overriding the background color also impacted the border color. With my changes, they are no longer linked. It's easier to override them separately, and the button now really has a border (not faked by the `::before`). Only the gradient on hover is part of the pseudo element.

3. I used css custom properties to share the border size & radius across the styles

4. Small little css improvement
* used shorthand property `inset` instead of `top right bottom left`
* managed to reduce the gradient size by 2. (It's not divided into 4 parts, 2 transparents and 2 for the real gradient, but in 2 parts now)
* removed `width: 100%` on the `::before`, it was not changing anything. If we need to set it for any reason, we'd need to set `box-sizing: content-box` so 100% = element width + border-width
* Moved `background: linear-gradient()` to `background-image: linear-gradient()` so it doesn't override other background properties like `background-size` if the line is set after.

```
background-size: 200%;
background: linear-gradient(); // Will override `background-size` because it's a shorthand property
```

> Note: it's a pleasure to work on this project, I'd be really happy if I could help more! Even small details like this :)