### PR TITLE
fix(ui-templates)!: switch to `useHead` import

### DIFF
--- a/packages/templates/lib/render.ts
+++ b/packages/templates/lib/render.ts
@@ -96,9 +96,9 @@ export const RenderPlugin = () => {
         }]))
         const vueCode = [
           '<script setup>',
-          title && 'import { useMeta } from \'#app\'',
+          title && 'import { useHead } from \'#imports\'',
           `const props = defineProps(${props})`,
-          title && 'useMeta(' + genObjectFromRawEntries([
+          title && 'useHead(' + genObjectFromRawEntries([
             ['title', `\`${title}\``],
             ['script', inlineScripts.map(s => ({ children: `\`${s}\`` }))],
             ['style', [{ children: `\`${globalStyles}\`` }]]


### PR DESCRIPTION
this will be a breaking change but will hide the warning `useMeta has been renamed to useHead`

Might be worth delaying merging this until just before we bump to `@nuxt/ui-templates` (without edge).