### PR TITLE
fix(ui): let nuxt/kit resolve module source

### DIFF
--- a/packages/ui/src/nuxt.ts
+++ b/packages/ui/src/nuxt.ts
@@ -1,9 +1,6 @@
 import { fileURLToPath } from 'url'
 import { addComponentsDir, defineNuxtModule, installModule } from '@nuxt/kit'
 import defu from 'defu'
-import UnocssModule from '@unocss/nuxt'
-import VueUseModule from '@vueuse/nuxt'
-import NuxtColorMode from '@nuxtjs/color-mode'
 import { extendUnocssOptions } from './unocss'
 
 const rPath = (p: string) => fileURLToPath(new URL(p, import.meta.url).toString())
@@ -33,9 +30,9 @@ export default defineNuxtModule({
     nuxt.options.vueuse = nuxt.options.vueuse || {}
     nuxt.options.colorMode = defu(nuxt.options.colorMode, { classSuffix: '' })
 
-    await installModule(UnocssModule)
-    await installModule(VueUseModule)
-    await installModule(NuxtColorMode)
+    await installModule('@unocss/nuxt')
+    await installModule('@vueuse/nuxt')
+    await installModule('@nuxtjs/color-mode')
   }
 })
 

--- a/packages/ui/src/nuxt.ts
+++ b/packages/ui/src/nuxt.ts
@@ -1,3 +1,7 @@
+/// <reference types="@unocss/nuxt" />
+/// <reference types="@vueuse/nuxt" />
+/// <reference types="@nuxtjs/color-mode" />
+
 import { fileURLToPath } from 'url'
 import { addComponentsDir, defineNuxtModule, installModule } from '@nuxt/kit'
 import defu from 'defu'

--- a/packages/ui/src/nuxt.ts
+++ b/packages/ui/src/nuxt.ts
@@ -3,7 +3,7 @@
 /// <reference types="@nuxtjs/color-mode" />
 
 import { fileURLToPath } from 'url'
-import { addComponentsDir, defineNuxtModule, installModule } from '@nuxt/kit'
+import { addComponentsDir, defineNuxtModule, installModule, logger, resolveModule } from '@nuxt/kit'
 import defu from 'defu'
 import { extendUnocssOptions } from './unocss'
 
@@ -34,9 +34,16 @@ export default defineNuxtModule({
     nuxt.options.vueuse = nuxt.options.vueuse || {}
     nuxt.options.colorMode = defu(nuxt.options.colorMode, { classSuffix: '' })
 
-    await installModule('@unocss/nuxt')
-    await installModule('@vueuse/nuxt')
-    await installModule('@nuxtjs/color-mode')
+    const modulesToInstall = [
+      '@unocss/nuxt',
+      '@vueuse/nuxt',
+      '@nuxtjs/color-mode',
+    ]
+
+    for (const mod of modulesToInstall) {
+      const modulePath = resolveModule(mod, { paths: import.meta.url })
+      await installModule(modulePath)
+    }
   }
 })
 

--- a/packages/ui/src/nuxt.ts
+++ b/packages/ui/src/nuxt.ts
@@ -3,7 +3,7 @@
 /// <reference types="@nuxtjs/color-mode" />
 
 import { fileURLToPath } from 'url'
-import { addComponentsDir, defineNuxtModule, installModule, logger, resolveModule } from '@nuxt/kit'
+import { addComponentsDir, defineNuxtModule, installModule, resolveModule } from '@nuxt/kit'
 import defu from 'defu'
 import { extendUnocssOptions } from './unocss'
 

--- a/packages/ui/src/nuxt.ts
+++ b/packages/ui/src/nuxt.ts
@@ -1,7 +1,3 @@
-/// <reference types="@unocss/nuxt" />
-/// <reference types="@vueuse/nuxt" />
-/// <reference types="@nuxtjs/color-mode" />
-
 import { fileURLToPath } from 'url'
 import { addComponentsDir, defineNuxtModule, installModule, createResolver } from '@nuxt/kit'
 import defu from 'defu'

--- a/packages/ui/src/nuxt.ts
+++ b/packages/ui/src/nuxt.ts
@@ -1,3 +1,7 @@
+/// <reference types="@unocss/nuxt" />
+/// <reference types="@vueuse/nuxt" />
+/// <reference types="@nuxtjs/color-mode" />
+
 import { fileURLToPath } from 'url'
 import { addComponentsDir, defineNuxtModule, installModule, createResolver } from '@nuxt/kit'
 import defu from 'defu'

--- a/packages/ui/src/nuxt.ts
+++ b/packages/ui/src/nuxt.ts
@@ -37,7 +37,7 @@ export default defineNuxtModule({
     const modulesToInstall = [
       '@unocss/nuxt',
       '@vueuse/nuxt',
-      '@nuxtjs/color-mode',
+      '@nuxtjs/color-mode'
     ]
 
     for (const mod of modulesToInstall) {

--- a/packages/ui/src/nuxt.ts
+++ b/packages/ui/src/nuxt.ts
@@ -1,9 +1,5 @@
-/// <reference types="@unocss/nuxt" />
-/// <reference types="@vueuse/nuxt" />
-/// <reference types="@nuxtjs/color-mode" />
-
 import { fileURLToPath } from 'url'
-import { addComponentsDir, defineNuxtModule, installModule, resolveModule } from '@nuxt/kit'
+import { addComponentsDir, defineNuxtModule, installModule, createResolver } from '@nuxt/kit'
 import defu from 'defu'
 import { extendUnocssOptions } from './unocss'
 
@@ -34,16 +30,10 @@ export default defineNuxtModule({
     nuxt.options.vueuse = nuxt.options.vueuse || {}
     nuxt.options.colorMode = defu(nuxt.options.colorMode, { classSuffix: '' })
 
-    const modulesToInstall = [
-      '@unocss/nuxt',
-      '@vueuse/nuxt',
-      '@nuxtjs/color-mode'
-    ]
-
-    for (const mod of modulesToInstall) {
-      const modulePath = resolveModule(mod, { paths: import.meta.url })
-      await installModule(modulePath)
-    }
+    const resolver = createResolver(import.meta.url)
+    await installModule(await resolver.resolvePath('@unocss/nuxt'))
+    await installModule(await resolver.resolvePath('@vueuse/nuxt'))
+    await installModule(await resolver.resolvePath('@nuxtjs/color-mode'))
   }
 })
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,10 @@
     "noUnusedLocals": true,
     "resolveJsonModule": true,
     "types": [
-      "node"
+      "node",
+      "@unocss/nuxt",
+      "@vueuse/nuxt",
+      "@nuxtjs/color-mode"
     ]
   },
   "exclude": [


### PR DESCRIPTION
Currently getting issues with this module importing `default` in `nuxt/framework` whenever trying to run any of the examples locally. Might just be an issue with stubbing. (Reproduction is simply `yarn nuxi dev examples/routing/pages` for example.)

```bash
 ERROR  Cannot start nuxt:  The requested module '@nuxt/kit' does not provide an export named 'addComponentsDir'

  import { defineNuxtModule, addPluginTemplate, addComponentsDir, extendViteConfig, extendWebpackConfig } from '@nuxt/kit';
  ^^^^^^^^^^^^^^^^
```

@pi0 is there any reason we shouldn't let user override version of the dependent modules via their own dependency tree?

**Note**: this PR doesn't fix the problem but makes it possible to fix the problem by updating the `resolveModule` function in `@nuxt/kit`...