### PR TITLE
ci: fix nightly release job conditional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
         if: |
           github.event_name == 'push' &&
           !contains(github.event.head_commit.message, '[skip-release]') &&
-          !contains(github.event.head_commit.message, 'chore') &&
-          !contains(github.event.head_commit.message, 'docs')
+          !startsWith(github.event.head_commit.message, 'chore') &&
+          !startsWith(github.event.head_commit.message, 'docs')
         run: ./scripts/release-edge.sh
         env:
           NODE_AUTH_TOKEN: ${{secrets.NODE_AUTH_TOKEN}}


### PR DESCRIPTION
This fixes the nightly release job conditional so it only checks the merge commit title and not the squashed commits in the commit body. This could incorrectly skip/prevent a release if the body contains one of the checked keywords.